### PR TITLE
Fix URLs for GeNet and Refraction projects

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -37,7 +37,7 @@ enableEmoji = true
   [[menu.main]]
     name = "GeNet"
     parent = "Projects"
-    url = "https://github.com/GregDomzalski/Refraction"
+    url = "https://github.com/GregDomzalski/GeNet"
     weight = 10
     [menu.main.params]
       rel = "external"
@@ -46,7 +46,7 @@ enableEmoji = true
   [[menu.main]]
     name = "Refraction"
     parent = "Projects"
-    url = "https://github.com/GregDomzalski/GeNet"
+    url = "https://github.com/GregDomzalski/Refraction"
     weight = 20
     [menu.main.params]
       rel = "external"


### PR DESCRIPTION
Oh hey, @GregDomzalski! Long time. I found a bug, so here's a simple PR to fix it. It appears that Refraction either isn't public or was deleted, but I'm just fixing the URLs that were swapped.

